### PR TITLE
Fix batch processing script

### DIFF
--- a/dldirect/scripts/direct.sh
+++ b/dldirect/scripts/direct.sh
@@ -25,7 +25,7 @@ fi
 
 SUBJECT_ID=$1
 DST=$2
-SCRIPT_DIR=`dirname $0`
+SCRIPT_DIR=`dirname $0`/..
 
 [[ -f "${DST}/softmax_seg.nii.gz" ]] || die "Invalid OUTPUT_DIR '${DST}': no segmentation found. Did 'dl+direct.sh --no-cth' run?"
 


### PR DESCRIPTION
Updated paths to Scripts folder in dldirect.sh, which is called by batch-dl+direct.sh, to handle new folder structure after python module refactoring